### PR TITLE
Fix: Footer Logo Url changed from absolute to relative

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -8,7 +8,7 @@
           <div class="col-12">
             <div class="row">
               <div>
-                <a href="https://circuitverse.org">
+                <a href="/">
                   <%= image_tag("CircuitVerseNew.png", class: "logo-bottom", alt: "CircuitVerse logo") %>
                 </a>
               </div>


### PR DESCRIPTION

Fixes # Fix: Footer Logo Url changed from absolute to relative

#### Describe the changes you have made in this PR -
Fix: Footer Logo Url changed from absolute to relative

### Screenshots of the changes (If any) -
